### PR TITLE
feat(git): activate pre-commit and pre-push hooks, require pre-commit

### DIFF
--- a/plugins/git/.claude-plugin/plugin.json
+++ b/plugins/git/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "git",
-  "version": "1.1.0",
-  "description": "SessionStart hook that ensures pre-commit pre-push hooks are installed",
+  "version": "1.2.0",
+  "description": "SessionStart hook that installs pre-commit and ensures pre-commit/pre-push hooks are active",
   "author": {
     "name": "enxebre"
   },

--- a/plugins/git/CLAUDE.md
+++ b/plugins/git/CLAUDE.md
@@ -1,6 +1,7 @@
 # Git Plugin
 
-Ensures pre-commit pre-push hooks are installed at session start. If the repo
-has a `.pre-commit-config.yaml` but no `.git/hooks/pre-push`, the plugin runs
-`pre-commit install --hook-type pre-push` automatically. After that, git-native
-hooks gate every push (from Claude or terminal) at zero token cost.
+Ensures pre-commit hooks are active at session start. If the repo has a
+`.pre-commit-config.yaml`, the plugin runs `pre-commit install --hook-type pre-commit`
+and `pre-commit install --hook-type pre-push`. Fails if pre-commit is not
+installed. After activation, git-native hooks gate every commit and push
+(from Claude or terminal) at zero token cost.

--- a/plugins/git/scripts/ensure-pre-push.sh
+++ b/plugins/git/scripts/ensure-pre-push.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ ! -f .git/hooks/pre-push ]; then
-  if command -v pre-commit &>/dev/null && [ -f .pre-commit-config.yaml ]; then
-    pre-commit install --hook-type pre-push >&2
-    echo "pre-push hook installed via pre-commit" >&2
-  fi
+if [ ! -f .pre-commit-config.yaml ]; then
+  exit 0
 fi
 
-exit 0
+if ! command -v pre-commit &>/dev/null; then
+  echo "ERROR: pre-commit is required but not found on PATH" >&2
+  exit 1
+fi
+
+pre-commit install --hook-type pre-commit >&2
+pre-commit install --hook-type pre-push >&2
+echo "pre-commit hooks installed" >&2

--- a/plugins/git/scripts/ensure-pre-push.sh
+++ b/plugins/git/scripts/ensure-pre-push.sh
@@ -7,7 +7,7 @@ fi
 
 if ! command -v pre-commit &>/dev/null; then
   echo "ERROR: pre-commit is required but not found on PATH" >&2
-  exit 1
+  exit 2
 fi
 
 pre-commit install --hook-type pre-commit >&2


### PR DESCRIPTION
## Summary
- Adds Claude Code plugin marketplace with a git plugin
- SessionStart hook activates both `pre-commit` and `pre-push` hook types when `.pre-commit-config.yaml` exists
- Exits with code 2 (blocking session) if `pre-commit` is not installed on PATH
- Benefits from hypershift pre-commit config (e.g. https://github.com/openshift/hypershift/pull/8701)

## Test plan
- [ ] Install plugin in a repo with `.pre-commit-config.yaml` and `pre-commit` on PATH — hooks should be installed
- [ ] Install plugin in a repo with `.pre-commit-config.yaml` but without `pre-commit` — session should be blocked (exit 2)
- [ ] Install plugin in a repo without `.pre-commit-config.yaml` — should pass silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)